### PR TITLE
repro: state-push test trigger

### DIFF
--- a/main/00_local_exec/README.md
+++ b/main/00_local_exec/README.md
@@ -57,3 +57,5 @@ Workspace working directory should be the Terraform root (**`main/00_local_exec/
 <!-- vcs state-push repro 1786013968 #3 -->
 
 <!-- vcs state-push repro 1786014473 #4 -->
+
+<!-- vcs state-push repro 1786014982 #5 -->

--- a/main/00_local_exec/README.md
+++ b/main/00_local_exec/README.md
@@ -51,3 +51,5 @@ Workspace working directory should be the Terraform root (**`main/00_local_exec/
 <!-- vcs state-push repro 1786010313 #2 -->
 
 <!-- vcs state-push repro 1786012951 #1 -->
+
+<!-- vcs state-push repro 1786013458 #2 -->

--- a/main/00_local_exec/README.md
+++ b/main/00_local_exec/README.md
@@ -45,3 +45,5 @@ Workspace working directory should be the Terraform root (**`main/00_local_exec/
 <!-- retry marker 2: 20260805T090322Z -->
 
 <!-- vcs state-push repro 1786009772 #1 -->
+
+<!-- vcs state-push repro 1786009864 #1 -->

--- a/main/00_local_exec/README.md
+++ b/main/00_local_exec/README.md
@@ -55,3 +55,5 @@ Workspace working directory should be the Terraform root (**`main/00_local_exec/
 <!-- vcs state-push repro 1786013458 #2 -->
 
 <!-- vcs state-push repro 1786013968 #3 -->
+
+<!-- vcs state-push repro 1786014473 #4 -->

--- a/main/00_local_exec/README.md
+++ b/main/00_local_exec/README.md
@@ -49,3 +49,5 @@ Workspace working directory should be the Terraform root (**`main/00_local_exec/
 <!-- vcs state-push repro 1786009864 #1 -->
 
 <!-- vcs state-push repro 1786010313 #2 -->
+
+<!-- vcs state-push repro 1786012951 #1 -->

--- a/main/00_local_exec/README.md
+++ b/main/00_local_exec/README.md
@@ -43,3 +43,5 @@ Workspace working directory should be the Terraform root (**`main/00_local_exec/
 <!-- repro trigger marker: 20260805T090021Z -->
 <!-- retry marker: 20260805T090213Z -->
 <!-- retry marker 2: 20260805T090322Z -->
+
+<!-- vcs state-push repro 1786009772 #1 -->

--- a/main/00_local_exec/README.md
+++ b/main/00_local_exec/README.md
@@ -42,3 +42,4 @@ These commands assume a **Linux-style** runner (`bash`, `python3`, `dd`, `/tmp`)
 Workspace working directory should be the Terraform root (**`main/00_local_exec/`** when the VCS root is **`base/`**) so **`bash term_trap.sh`** and **`bash term_trap_data_external.sh`** resolve next to the config.
 <!-- repro trigger marker: 20260805T090021Z -->
 <!-- retry marker: 20260805T090213Z -->
+<!-- retry marker 2: 20260805T090322Z -->

--- a/main/00_local_exec/README.md
+++ b/main/00_local_exec/README.md
@@ -41,3 +41,4 @@ These commands assume a **Linux-style** runner (`bash`, `python3`, `dd`, `/tmp`)
 
 Workspace working directory should be the Terraform root (**`main/00_local_exec/`** when the VCS root is **`base/`**) so **`bash term_trap.sh`** and **`bash term_trap_data_external.sh`** resolve next to the config.
 <!-- repro trigger marker: 20260805T090021Z -->
+<!-- retry marker: 20260805T090213Z -->

--- a/main/00_local_exec/README.md
+++ b/main/00_local_exec/README.md
@@ -40,3 +40,4 @@ Values below match the **`command_for_local_exec`** strings in the corresponding
 These commands assume a **Linux-style** runner (`bash`, `python3`, `dd`, `/tmp`). Adjust paths or drop-in equivalents if your environment differs.
 
 Workspace working directory should be the Terraform root (**`main/00_local_exec/`** when the VCS root is **`base/`**) so **`bash term_trap.sh`** and **`bash term_trap_data_external.sh`** resolve next to the config.
+<!-- repro trigger marker: 20260805T090021Z -->

--- a/main/00_local_exec/README.md
+++ b/main/00_local_exec/README.md
@@ -53,3 +53,5 @@ Workspace working directory should be the Terraform root (**`main/00_local_exec/
 <!-- vcs state-push repro 1786012951 #1 -->
 
 <!-- vcs state-push repro 1786013458 #2 -->
+
+<!-- vcs state-push repro 1786013968 #3 -->

--- a/main/00_local_exec/README.md
+++ b/main/00_local_exec/README.md
@@ -47,3 +47,5 @@ Workspace working directory should be the Terraform root (**`main/00_local_exec/
 <!-- vcs state-push repro 1786009772 #1 -->
 
 <!-- vcs state-push repro 1786009864 #1 -->
+
+<!-- vcs state-push repro 1786010313 #2 -->


### PR DESCRIPTION
Testing whether VCS-triggered dry runs (fresh config version) behave differently from API-triggered ones for the dry-run-pushes-state investigation. Safe to close/ignore.