### PR TITLE
Clean up policy definitions in scalr-policy.hcl

### DIFF
--- a/policies/fail_expose_metadata/scalr-policy.hcl
+++ b/policies/fail_expose_metadata/scalr-policy.hcl
@@ -9,18 +9,3 @@ policy "http_send" {
     enabled = true
     enforcement_level = "advisory"
 }
-
-policy "advisory" {
-  enabled           = true
-  enforcement_level = "advisory"
-}
-
-policy "soft-mandatory" {
-  enabled           = true
-  enforcement_level = "soft-mandatory"
-}
-
-policy "hard-mandatory" {
-  enabled           = true
-  enforcement_level = "hard-mandatory"
-}


### PR DESCRIPTION
Removed unnecessary policies for advisory and mandatory enforcement levels.